### PR TITLE
[2.0.r1] disable local service.xml

### DIFF
--- a/hal/Android.bp
+++ b/hal/Android.bp
@@ -47,7 +47,6 @@ cc_binary {
     ],
 
     init_rc: ["android.hardware.usb.gadget@1.1-service-qti.rc"],
-    vintf_fragments: ["android.hardware.usb.gadget@1.1-service.xml"],
 }
 
 prebuilt_etc {


### PR DESCRIPTION
disable local android.hardware.usb.gadget@1.1-service.xml to avoid conflict with AOSP one